### PR TITLE
Add required powershell version to migration scripts

### DIFF
--- a/DeleteNSGFlowLogs.ps1
+++ b/DeleteNSGFlowLogs.ps1
@@ -1,5 +1,6 @@
 #// Copyright (c) Microsoft Corporation.
 #// Licensed under the MIT license.
+#Requires -Version 7.2
 
 #region Global
 

--- a/MigrationFromNsgToAzureFlowLogging.ps1
+++ b/MigrationFromNsgToAzureFlowLogging.ps1
@@ -1,5 +1,6 @@
 #// Copyright (c) Microsoft Corporation.
 #// Licensed under the MIT license.
+#Requires -Version 7.2
 
 #region Globals
 


### PR DESCRIPTION
These scripts uses some powershell version specific constructs, so added required version in script to fail running of script at the onset if a lower than required version is used